### PR TITLE
Starting the base for generating and saving the diffs

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -6,7 +6,7 @@
     "eqeqeq": true,
     "immed": true,
     "indent": 2,
-    "latedef": true,
+    "latedef": "func",
     "loopfunc": true,
     "newcap": true,
     "noarg": true,

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,13 @@
 version: "{build}"
 
 environment:
-  nodejs_version: "0.12"
+  matrix:
+  # node.js
+  - nodejs_version: "0.12"
+  - nodejs_version: "0.10"
+
+  # io.js
+  - nodejs_version: "1.5.0"
 
 matrix:
   fast_finish: true

--- a/server/checkBuild.js
+++ b/server/checkBuild.js
@@ -62,10 +62,28 @@ function diffCommonBrowsers(options) {
         head: head,
         base: base,
         browser: browser
+      })
+      .then(function(result) {
+        if (result.length > 0) {
+          return {
+            browser: browser,
+            images: result
+          };
+        }
       });
     });
 
-    return Bluebird.all(imagePromises);
+    return Bluebird.all(imagePromises)
+    .then(function(browsers) {
+      return browsers.filter(function(browser) {
+        return browser !== undefined;
+      })
+      .reduce(function(obj, browser) {
+        obj[browser.browser] = browser.images;
+
+        return obj;
+      }, {});
+    });
   });
 }
 

--- a/server/checkBuild.js
+++ b/server/checkBuild.js
@@ -29,6 +29,9 @@ function buildReceived(payload) {
       head: buildInfo.head,
       base: buildInfo.base
     });
+  })
+  .then(function(result) {
+
   });
 }
 
@@ -51,7 +54,7 @@ function diffCommonBrowsers(options) {
     });
 
     var imagePromises = commonBrowsers.map(function(browser) {
-      return generateDiffImages({
+      return diffBrowser({
         head: head,
         base: base,
         browser: browser
@@ -59,15 +62,6 @@ function diffCommonBrowsers(options) {
     });
 
     return Bluebird.all(imagePromises);
-
-    // if head browsers === base browsers, obv
-    // if head browsers is subset of base browsers
-    //    use head browsers
-    // if base browsers is subset of head browsers
-    //    use base browsers
-
-    // use only the browsers they have in common
-
   });
 }
 
@@ -76,7 +70,9 @@ options.head string
 options.base string
 options.browser string
 */
-function generateDiffImages() {}
+function diffBrowser(options) {
+
+}
 
 dispatcher.on('buildReceived', buildReceived);
 
@@ -91,6 +87,15 @@ if (process.env.NODE_ENV === 'test') {
     },
     set: function(newFunc) {
       diffCommonBrowsers = newFunc;
+    }
+  });
+
+  Object.defineProperty(visible, '_diffBrowser', {
+    get: function() {
+      return diffBrowser;
+    },
+    set: function(newFunc) {
+      diffBrowser = newFunc;
     }
   });
 

--- a/server/checkBuild.js
+++ b/server/checkBuild.js
@@ -103,10 +103,20 @@ function diffBrowser(options) {
         base: base,
         browser: browser,
         image: image
+      })
+      .then(function(result) {
+        if (result.diff === true) {
+          return image;
+        }
       });
     });
 
-    return Bluebird.all(imagePromises);
+    return Bluebird.all(imagePromises)
+    .then(function(results) {
+      return results.filter(function(result) {
+        return result !== undefined;
+      });
+    });
   });
 }
 

--- a/server/checkBuild.js
+++ b/server/checkBuild.js
@@ -60,6 +60,7 @@ function diffCommonBrowsers(options) {
 
     return Bluebird.all(imagePromises);
 
+
     // if head browsers === base browsers, obv
     // if head browsers is subset of base browsers
     //    use head browsers

--- a/server/checkBuild.js
+++ b/server/checkBuild.js
@@ -9,7 +9,7 @@ payload.id string
 */
 function buildReceived(payload) {
   if (payload === undefined || payload.id === undefined) {
-    throw new Error('Payload must contain an id');
+    return new Bluebird.reject(new Error('Payload must contain an id'));
   }
 
   var buildId = payload.id;
@@ -41,7 +41,7 @@ function diffCommonBrowsers(options) {
   var head = options.head;
   var base = options.base;
 
-  return Bluebird.join([
+  return Bluebird.all([
     storage.getBrowsersForSha(head),
     storage.getBrowsersForSha(base)
     ])
@@ -59,7 +59,6 @@ function diffCommonBrowsers(options) {
     });
 
     return Bluebird.all(imagePromises);
-
 
     // if head browsers === base browsers, obv
     // if head browsers is subset of base browsers

--- a/server/checkBuild.js
+++ b/server/checkBuild.js
@@ -30,11 +30,20 @@ function buildReceived(payload) {
       build: buildId,
       head: buildInfo.head,
       base: buildInfo.base
+    })
+    .then(function(result) {
+      if (Object.keys(result).length > 0) {
+        return storage.updateBuild(buildId, {
+          status: 'failed',
+          diff: result
+        });
+      } else {
+        return storage.updateBuild(buildId, {
+          status: 'success'
+        });
+      }
     });
-  })
-  .then(function(result) {
-
-  })
+  });
 }
 
 /*

--- a/server/routes.js
+++ b/server/routes.js
@@ -63,7 +63,6 @@ module.exports = function(app) {
       head: {SHA},
       base: {SHA},
       status: "success" // either "failed", "success"
-      browsers: ['Chrome 28', 'Firefox 34', 'IE 8'],
       diffs: {
           'Chrome 28': [
               'homepage.navbar.700.png',

--- a/server/utils/differ.js
+++ b/server/utils/differ.js
@@ -1,18 +1,39 @@
 'use strict';
 
 var Bluebird = require('bluebird');
+var resemble = require('node-resemble-js');
+var TarHelper = require('./tarHelper');
 
 var differ = {
   /*
-  image1.width int
-  image1.height int
-  image1.data Buffer
-  image2.width int
-  image2.height int
-  image2.data Buffer
+  image1 pngjs
+  image2 pngjs
+
+  resolves
+  {
+    distance number
+    image pngjs
+  }
   */
   generateDiff: function(image1, image2) {
-    return Bluebird.resolve();
+    return Bluebird.all([
+      TarHelper.imageData(image1),
+      TarHelper.imageData(image2)
+    ])
+    .spread(function(image1Data, image2Data) {
+      return new Bluebird(function(resolve) {
+        resemble(image1Data)
+        .compareTo(image2Data)
+        .onComplete(function(image) {
+          var diffImage = image.getDiffImage();
+
+          resolve({
+            distance: image.misMatchPercentage,
+            image: diffImage
+          });
+        });
+      });
+    });
   }
 };
 

--- a/server/utils/differ.js
+++ b/server/utils/differ.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var Bluebird = require('bluebird');
+
+var differ = {
+  /*
+  image1.width int
+  image1.height int
+  image1.data Buffer
+  image2.width int
+  image2.height int
+  image2.data Buffer
+  */
+  generateDiff: function(image1, image2) {
+    return Bluebird.resolve();
+  }
+};
+
+module.exports = differ;

--- a/server/utils/storage.js
+++ b/server/utils/storage.js
@@ -92,6 +92,30 @@ var Storage = {
   },
 
   /*
+  id string
+  options.status string
+  [options.diff object]
+  */
+  updateBuildInfo: function(id, options) {
+    var buildFile = path.join(buildsPath, id, 'build.json');
+    var status = options.status;
+    var diff = options.diff;
+
+    return fs.readJSONAsync(buildFile)
+    .then(function(data) {
+      data.status = status;
+
+      if (status === 'success') {
+        delete data.diff;
+      } else if (status === 'failure') {
+        data.diff = diff;
+      }
+
+      return fs.outputJSONAsync(buildFile, data);
+    });
+  },
+
+  /*
   sha string
   */
   getBrowsersForSha: function(sha) {

--- a/server/utils/storage.js
+++ b/server/utils/storage.js
@@ -146,7 +146,7 @@ var Storage = {
   options.browser string
   options.image string
 
-  returns Buffer
+  resolves pngjs
   */
   getImage: function(options) {
     var sha = options.sha;
@@ -157,11 +157,7 @@ var Storage = {
 
     return PNGImage.readImageAsync(imagePath)
     .then(function(image) {
-      return {
-        width: image.getWidth(),
-        height: image.getHeight(),
-        data: image.getBlob()
-      };
+      return image.getImage();
     });
   },
 
@@ -169,7 +165,7 @@ var Storage = {
   options.build string
   options.browser string
   options.imageName string
-  options.imageData Buffer
+  options.imageData pngjs
   */
   saveDiffImage: function(options) {
     var build = options.build;

--- a/server/utils/storage.js
+++ b/server/utils/storage.js
@@ -5,6 +5,7 @@ var fs = Bluebird.promisifyAll(require('fs-extra'));
 var path = require('path');
 var uuid = require('node-uuid');
 var tar = require('tar-fs');
+var dirHelper = require('./dirHelper');
 
 var root = path.join(__dirname, '..', '..');
 var dataPath = path.join(root, 'data');
@@ -101,6 +102,18 @@ var Storage = {
         return fs.statSync(path.join(shaPath, file)).isDirectory();
       });
     });
+  },
+
+  /*
+  options.sha string
+  options.browser string
+  */
+  getImagesForShaBrowser: function(options) {
+    var sha = options.sha;
+    var browser = options.browser;
+
+    var browserPath = path.join(shasPath, sha, browser);
+    return dirHelper.readFiles(browserPath);
   }
 };
 

--- a/server/utils/storage.js
+++ b/server/utils/storage.js
@@ -139,6 +139,26 @@ var Storage = {
         data: image.getBlob()
       };
     });
+  },
+
+  /*
+  options.build string
+  options.browser string
+  options.imageName string
+  options.imageData Buffer
+  */
+  saveDiffImage: function(options) {
+    var build = options.build;
+    var browser = options.browser;
+    var imageName = options.imageName;
+    var imageData = options.imageData;
+
+    var imagePath = path.join(buildsPath, build, browser, imageName);
+
+    return fs.outputFileAsync(imagePath, imageData)
+    .then(function() {
+      // Keep any data from returning
+    });
   }
 };
 

--- a/server/utils/storage.js
+++ b/server/utils/storage.js
@@ -5,6 +5,7 @@ var fs = Bluebird.promisifyAll(require('fs-extra'));
 var path = require('path');
 var uuid = require('node-uuid');
 var tar = require('tar-fs');
+var PNGImage = Bluebird.promisifyAll(require('pngjs-image'));
 var dirHelper = require('./dirHelper');
 
 var root = path.join(__dirname, '..', '..');
@@ -114,6 +115,30 @@ var Storage = {
 
     var browserPath = path.join(shasPath, sha, browser);
     return dirHelper.readFiles(browserPath);
+  },
+
+  /*
+  options.sha string
+  options.browser string
+  options.image string
+
+  returns Buffer
+  */
+  getImage: function(options) {
+    var sha = options.sha;
+    var browser = options.browser;
+    var image = options.image;
+
+    var imagePath = path.join(shasPath, sha, browser, image);
+
+    return PNGImage.readImageAsync(imagePath)
+    .then(function(image) {
+      return {
+        width: image.getWidth(),
+        height: image.getHeight(),
+        data: image.getBlob()
+      };
+    });
   }
 };
 

--- a/server/utils/tarHelper.js
+++ b/server/utils/tarHelper.js
@@ -102,6 +102,23 @@ var TarHelper = {
         return files;
       });
     });
+  },
+
+  imageData: function(pngjs) {
+    return new Bluebird(function(resolve, reject) {
+      var buffers = [];
+      pngjs.pack()
+      .on('data', function(data) {
+        buffers.push(data);
+      })
+      .on('end', function() {
+        var buffer = Buffer.concat(buffers);
+        resolve(buffer);
+      })
+      .on('error', function(error) {
+        reject(error);
+      });
+    });
   }
 };
 

--- a/test/checkBuild.js
+++ b/test/checkBuild.js
@@ -26,14 +26,7 @@ describe('module/checkBuild', function() {
     });
   });
 
-  describe('buildReceived', function() {
-    var diffCommonBrowsersSpy;
-
-    beforeEach(function() {
-      diffCommonBrowsersSpy = this.sinon.spy();
-      checkBuild._diffCommonBrowsers = diffCommonBrowsersSpy;
-    });
-
+  describe('#buildReceived', function() {
     describe('with invalid payload', function() {
       it('should throw', function() {
         assert.throws(function() {
@@ -57,14 +50,17 @@ describe('module/checkBuild', function() {
         });
       });
 
-      it('should call calculateDiffs', function() {
+      it('should call diffCommonBrowsers', function() {
+        var spy = this.sinon.spy();
+        checkBuild._diffCommonBrowsers = spy;
+
         return checkBuild._buildReceived({
           id: 'foo'
         })
         .then(function() {
-          assert.calledWithExactly(diffCommonBrowsersSpy, {
+          assert.calledWithExactly(spy, {
             head: 'foo',
-            base: 'bar'
+            base: 'bar',
           });
         });
       });
@@ -85,18 +81,30 @@ describe('module/checkBuild', function() {
         });
       });
 
-      it('should call calculateDiffs', function() {
+      it('should not call diffCommonBrowsers', function() {
+        var spy = this.sinon.spy();
+        checkBuild._diffCommonBrowsers = spy;
+
         return checkBuild._buildReceived({
           id: 'foo'
         })
         .then(function() {
-          assert.callCount(diffCommonBrowsersSpy, 0);
+          assert.callCount(spy, 0);
         });
       });
     });
   });
 
-  describe('calculateDiffs', function() {
+  describe('#diffCommonBrowsers', function() {
+    describe('for build with same browsers', function() {
+      beforeEach(function() {
+        storageStub.getBrowsersForSha = this.sinon.stub()
+          .resolves(['Chrome', 'Firefox']);
+      })
 
+      it('calls diffBrowsers for both browsers', function() {
+        // checkBuild._diffCommonBrowsers()
+      })
+    })
   });
 });

--- a/test/checkBuild.js
+++ b/test/checkBuild.js
@@ -4,6 +4,7 @@ var proxyquire = require('proxyquire');
 var Bluebird = require('bluebird');
 require('mocha-sinon');
 require('sinon-as-promised')(Bluebird);
+var TarHelper = require('../server/utils/tarHelper');
 
 describe('module/checkBuild', function() {
   var storageStub = {};
@@ -494,17 +495,8 @@ describe('module/checkBuild', function() {
     });
 
     it('calls generateDiff with results from head and base', function() {
-      var image1Result = {
-        width: 200,
-        height: 300,
-        buffer: new Buffer([1])
-      };
-
-      var image2Result = {
-        width: 300,
-        height: 200,
-        buffer: new Buffer([])
-      };
+      var image1Result = TarHelper.createImage().getImage();
+      var image2Result = TarHelper.createImage().getImage();
 
       storageStub.getImage.withArgs({
         sha: options.head,
@@ -528,13 +520,13 @@ describe('module/checkBuild', function() {
       });
     });
 
-    describe('with generateDiff', function() {
+    describe('with diff', function() {
       var imageBuffer;
 
       beforeEach(function() {
         storageStub.saveDiffImage = this.sinon.stub().resolves();
 
-        imageBuffer = new Buffer([]);
+        imageBuffer = TarHelper.createImage().getImage();
       });
 
       describe('distance greater than threshold', function() {

--- a/test/checkBuild.js
+++ b/test/checkBuild.js
@@ -26,80 +26,77 @@ describe('module/checkBuild', function() {
     });
   });
 
-  describe('with invalid payload', function() {
-    it('should throw', function() {
-      assert.throws(function() {
-        checkBuild._buildReceived();
-      });
-    });
-  });
+  describe('buildReceived', function() {
+    var diffCommonBrowsersSpy;
 
-  describe('with completed build', function() {
     beforeEach(function() {
-      storageStub.getBrowsersForSha = this.sinon.stub()
-      .withArgs('foo')
-      .resolves(['Chrome', 'Firefox']);
+      diffCommonBrowsersSpy = this.sinon.spy();
+      checkBuild._diffCommonBrowsers = diffCommonBrowsersSpy;
     });
 
-    it('should not throw', function() {
-      assert.doesNotThrow(function() {
-        checkBuild._buildReceived({
-          id: 'foo'
+    describe('with invalid payload', function() {
+      it('should throw', function() {
+        assert.throws(function() {
+          checkBuild._buildReceived();
         });
       });
     });
 
-    it('should call calculateDiffs', function() {
-      var spy = this.sinon.spy();
-      checkBuild._calculateDiffs = spy;
+    describe('with completed build', function() {
+      beforeEach(function() {
+        storageStub.getBrowsersForSha = this.sinon.stub()
+        .withArgs('foo')
+        .resolves(['Chrome', 'Firefox']);
+      });
 
-      return checkBuild._buildReceived({
-        id: 'foo'
-      })
-      .then(function() {
-        assert.calledWithExactly(spy, {
-          buildInfo: {
+      it('should not throw', function() {
+        assert.doesNotThrow(function() {
+          checkBuild._buildReceived({
+            id: 'foo'
+          });
+        });
+      });
+
+      it('should call calculateDiffs', function() {
+        return checkBuild._buildReceived({
+          id: 'foo'
+        })
+        .then(function() {
+          assert.calledWithExactly(diffCommonBrowsersSpy, {
             head: 'foo',
-            base: 'bar',
-            numBrowsers: 2
-          },
-          browsers: ['Chrome', 'Firefox']
+            base: 'bar'
+          });
         });
       });
     });
-  });
 
-  describe('with non-completed build', function() {
-    beforeEach(function() {
-      storageStub.getBrowsersForSha = this.sinon.stub()
-      .withArgs('foo')
-      .resolves(['Chrome']);
-    });
+    describe('with non-completed build', function() {
+      beforeEach(function() {
+        storageStub.getBrowsersForSha = this.sinon.stub()
+        .withArgs('foo')
+        .resolves(['Chrome']);
+      });
 
-    it('should not throw', function() {
-      assert.doesNotThrow(function() {
-        checkBuild._buildReceived({
+      it('should not throw', function() {
+        assert.doesNotThrow(function() {
+          checkBuild._buildReceived({
+            id: 'foo'
+          });
+        });
+      });
+
+      it('should call calculateDiffs', function() {
+        return checkBuild._buildReceived({
           id: 'foo'
+        })
+        .then(function() {
+          assert.callCount(diffCommonBrowsersSpy, 0);
         });
-      });
-    });
-
-    it('should call calculateDiffs', function() {
-      var spy = this.sinon.spy();
-      checkBuild._calculateDiffs = spy;
-
-      return checkBuild._buildReceived({
-        id: 'foo'
-      })
-      .then(function() {
-        assert.callCount(spy, 0);
       });
     });
   });
 
-
-
-  it('should call storage.getBuild', function() {
+  describe('calculateDiffs', function() {
 
   });
 });

--- a/test/checkBuild.js
+++ b/test/checkBuild.js
@@ -425,8 +425,12 @@ describe('module/checkBuild', function() {
     });
 
     describe('with generateDiff', function() {
+      var imageBuffer;
+
       beforeEach(function() {
         storageStub.saveDiffImage = this.sinon.stub().resolves();
+
+        imageBuffer = new Buffer([]);
       });
 
       describe('distance greater than threshold', function() {
@@ -434,7 +438,7 @@ describe('module/checkBuild', function() {
           differStub.generateDiff = this.sinon.stub()
           .resolves({
             distance: 0.3,
-            image: new Buffer([])
+            image: imageBuffer
           });
         });
 
@@ -451,7 +455,7 @@ describe('module/checkBuild', function() {
               build: 'build',
               browser: 'Chrome',
               imageName: 'navbar.png',
-              imageData: new Buffer([])
+              imageData: imageBuffer
             }));
           });
         });
@@ -474,7 +478,7 @@ describe('module/checkBuild', function() {
           differStub.generateDiff = this.sinon.stub()
           .resolves({
             distance: 0,
-            image: new Buffer([])
+            image: imageBuffer
           });
         });
 
@@ -491,7 +495,7 @@ describe('module/checkBuild', function() {
               build: 'build',
               browser: 'Chrome',
               imageName: 'navbar.png',
-              imageData: new Buffer([])
+              imageData: imageBuffer
             }));
           });
         });

--- a/test/checkBuild.js
+++ b/test/checkBuild.js
@@ -29,9 +29,7 @@ describe('module/checkBuild', function() {
   describe('#buildReceived', function() {
     describe('with invalid payload', function() {
       it('should throw', function() {
-        assert.throws(function() {
-          checkBuild._buildReceived();
-        });
+        return assert.isRejected(checkBuild._buildReceived());
       });
     });
 
@@ -42,12 +40,11 @@ describe('module/checkBuild', function() {
         .resolves(['Chrome', 'Firefox']);
       });
 
-      it('should not throw', function() {
-        assert.doesNotThrow(function() {
-          checkBuild._buildReceived({
-            id: 'foo'
-          });
-        });
+      it('should fulfill', function() {
+        return assert.isFulfilled(checkBuild._buildReceived({
+          id: 'foo'
+        }));
+
       });
 
       it('should call diffCommonBrowsers', function() {
@@ -60,7 +57,7 @@ describe('module/checkBuild', function() {
         .then(function() {
           assert.calledWithExactly(spy, {
             head: 'foo',
-            base: 'bar',
+            base: 'bar'
           });
         });
       });
@@ -74,11 +71,9 @@ describe('module/checkBuild', function() {
       });
 
       it('should not throw', function() {
-        assert.doesNotThrow(function() {
-          checkBuild._buildReceived({
-            id: 'foo'
-          });
-        });
+        return assert.isFulfilled(checkBuild._buildReceived({
+          id: 'foo'
+        }));
       });
 
       it('should not call diffCommonBrowsers', function() {
@@ -100,11 +95,11 @@ describe('module/checkBuild', function() {
       beforeEach(function() {
         storageStub.getBrowsersForSha = this.sinon.stub()
           .resolves(['Chrome', 'Firefox']);
-      })
+      });
 
       it('calls diffBrowsers for both browsers', function() {
         // checkBuild._diffCommonBrowsers()
-      })
-    })
+      });
+    });
   });
 });

--- a/test/checkBuild.js
+++ b/test/checkBuild.js
@@ -21,8 +21,8 @@ describe('module/checkBuild', function() {
 
     storageStub.getBuildInfo = this.sinon.stub()
     .resolves({
-      head: 'foo',
-      base: 'bar',
+      head: 'head',
+      base: 'base',
       numBrowsers: 2
     });
 
@@ -48,7 +48,7 @@ describe('module/checkBuild', function() {
     describe('with completed build', function() {
       beforeEach(function() {
         storageStub.getBrowsersForSha = this.sinon.stub()
-        .withArgs('foo')
+        .withArgs('head')
         .resolves(['Chrome', 'Firefox']);
       });
 
@@ -57,9 +57,8 @@ describe('module/checkBuild', function() {
         .resolves(true);
 
         return assert.isFulfilled(checkBuild._buildReceived({
-          id: 'foo'
+          id: 'head'
         }));
-
       });
 
       it('should call diffCommonBrowsers', function() {
@@ -72,23 +71,31 @@ describe('module/checkBuild', function() {
         .then(function() {
           assert.calledWithExactly(spy, {
             build: 'build',
-            head: 'foo',
-            base: 'bar'
+            head: 'head',
+            base: 'base'
           });
         });
+      });
+
+      describe('with diffs', function() {
+        it('should fail');
+      });
+
+      describe('without diffs', function() {
+        it('should succeed');
       });
     });
 
     describe('with non-completed build', function() {
       beforeEach(function() {
         storageStub.getBrowsersForSha = this.sinon.stub()
-        .withArgs('foo')
+        .withArgs('head')
         .resolves(['Chrome']);
       });
 
       it('should not throw', function() {
         return assert.isFulfilled(checkBuild._buildReceived({
-          id: 'foo'
+          id: 'head'
         }));
       });
 
@@ -97,7 +104,7 @@ describe('module/checkBuild', function() {
         checkBuild._diffCommonBrowsers = spy;
 
         return checkBuild._buildReceived({
-          id: 'foo'
+          id: 'head'
         })
         .then(function() {
           assert.callCount(spy, 0);
@@ -407,8 +414,8 @@ describe('module/checkBuild', function() {
     beforeEach(function() {
       options = {
         build: 'build',
-        head: 'foo',
-        base: 'bar',
+        head: 'head',
+        base: 'base',
         browser: 'Safari',
         image: 'navbar.png'
       };

--- a/test/differ-test.js
+++ b/test/differ-test.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var TarHelper = require('../server/utils/tarHelper');
+var differ = require('../server/utils/differ');
+
+describe('module/differ', function() {
+  describe('#generateDiff', function() {
+    it('should print', function() {
+      var image1 = TarHelper.createImage().getImage();
+      var image2 = TarHelper.createImage().getImage();
+
+      return differ.generateDiff(image1, image2)
+      .then(function(result) {
+        assert.equal(result.distance, 0.0);
+        assert.isDefined(result.image.width);
+        assert.isDefined(result.image.data);
+      });
+    });
+  });
+});

--- a/test/storage-test.js
+++ b/test/storage-test.js
@@ -211,7 +211,7 @@ describe('module/storage', function() {
     });
   });
 
-  describe('#getImagesForShaBrowsers', function() {
+  describe('#getImagesForShaBrowser', function() {
     var readFilesSpy;
     var storage;
 

--- a/test/storage-test.js
+++ b/test/storage-test.js
@@ -281,7 +281,38 @@ describe('module/storage', function() {
           data: imageData.getBlob()
         });
       });
+    });
+  });
 
+  describe('#saveDiffImage', function() {
+    var options;
+
+    beforeEach(function() {
+      options = {
+        build: 'build',
+        browser: 'browser',
+        imageName: 'navbar.png',
+        imageData: new Buffer([])
+      };
+    });
+
+    it('should save a file', function() {
+      var diffPath = path.join(storage._buildsPath, options.build, options.browser, options.imageName);
+
+      return storage.saveDiffImage(options)
+      .then(function() {
+        return fs.statAsync(diffPath);
+      })
+      .then(function(file) {
+        return assert(file.isFile());
+      });
+    });
+
+    it('should swallow any output', function() {
+      return storage.saveDiffImage(options)
+      .then(function(output) {
+        assert.isUndefined(output);
+      });
     });
   });
 });

--- a/test/storage-test.js
+++ b/test/storage-test.js
@@ -343,12 +343,11 @@ describe('module/storage', function() {
           image: image
         });
       })
-      .then(function(data) {
-        assert.deepEqual(data, {
-          width: imageData.getWidth(),
-          height: imageData.getHeight(),
-          data: imageData.getBlob()
-        });
+      .then(function(image) {
+        assert.isDefined(image.width);
+        assert.isDefined(image.height);
+        assert.isDefined(image.data);
+        assert.isDefined(image.gamma);
       });
     });
   });
@@ -361,7 +360,7 @@ describe('module/storage', function() {
         build: 'build',
         browser: 'browser',
         imageName: 'navbar.png',
-        imageData: new Buffer([])
+        imageData: TarHelper.createImage().getImage()
       };
     });
 

--- a/test/storage-test.js
+++ b/test/storage-test.js
@@ -10,7 +10,7 @@ var storage = require('../server/utils/storage');
 var TarHelper = require('../server/utils/tarHelper');
 var DirHelper = require('../server/utils/dirHelper');
 
-describe('Storage', function() {
+describe('module/storage', function() {
   beforeEach(function() {
     mockFs();
   });

--- a/test/storage-test.js
+++ b/test/storage-test.js
@@ -32,8 +32,8 @@ describe('module/storage', function() {
 
   describe('#startBuild', function() {
     var buildOptions = {
-      head: 'abasdf',
-      base: 'bjasdf',
+      head: 'head',
+      base: 'base',
       numBrowsers: 3
     };
 
@@ -73,7 +73,7 @@ describe('module/storage', function() {
     });
 
     it('should', function() {
-      var sha = 'asdfasdf';
+      var sha = 'sha';
       var browser = 'Chrome 28';
       var expectedSavePath = path.join(sha, browser);
 
@@ -95,8 +95,8 @@ describe('module/storage', function() {
 
   describe('#hasBuild', function() {
     var buildOptions = {
-        head: 'abasdf',
-        base: 'bjasdf',
+        head: 'head',
+        base: 'base',
         numBrowsers: 3
       };
 
@@ -135,8 +135,8 @@ describe('module/storage', function() {
 
     it('should return build info', function() {
       var buildOptions = {
-        head: 'abasdf',
-        base: 'bjasdf',
+        head: 'head',
+        base: 'base',
         numBrowsers: 3
       };
 
@@ -154,6 +154,75 @@ describe('module/storage', function() {
         assert.isString(data.id);
         assert.equal(data.status, 'pending');
         assert.shallowDeepEqual(data, buildOptions);
+      });
+    });
+  });
+
+  describe('#updateBuildInfo', function() {
+    var buildId;
+
+    beforeEach(function() {
+      var buildOptions = {
+        head: 'head',
+        base: 'base',
+        numBrowsers: 3
+      };
+
+      return storage.startBuild(buildOptions)
+      .then(function(data) {
+        buildId = data.id;
+      });
+    });
+
+    describe('with success', function() {
+      beforeEach(function() {
+        return storage.updateBuildInfo(buildId, {
+          status: 'success'
+        });
+      });
+
+      it('should write success', function() {
+        return storage.getBuildInfo(buildId)
+        .then(function(buildInfo) {
+          assert.equal(buildInfo.status, 'success');
+        });
+      });
+
+      it('should not have a diff', function() {
+        return storage.getBuildInfo(buildId)
+        .then(function(buildInfo) {
+          assert.isUndefined(buildInfo.diff);
+        });
+      });
+    });
+
+    describe('with failure', function() {
+      var newBuildInfo;
+
+      beforeEach(function() {
+        newBuildInfo = {
+          status: 'failure',
+          diff: {
+            Chrome: ['image1.png,', 'image2.png'],
+            Firefox: ['image1.png']
+          }
+        };
+
+        return storage.updateBuildInfo(buildId, newBuildInfo);
+      });
+
+      it('should write failure', function() {
+        return storage.getBuildInfo(buildId)
+        .then(function(buildInfo) {
+          assert.equal(buildInfo.status, 'failure');
+        });
+      });
+
+      it('should have a diff', function() {
+        return storage.getBuildInfo(buildId)
+        .then(function(buildInfo) {
+          assert.deepEqual(buildInfo.diff, newBuildInfo.diff);
+        });
       });
     });
   });

--- a/test/storage-test.js
+++ b/test/storage-test.js
@@ -251,4 +251,37 @@ describe('module/storage', function() {
       });
     });
   });
+
+  describe('#getImage', function() {
+    it('should return width, height, and data', function() {
+      var imageData = TarHelper.createImage();
+
+      var sha = 'foo';
+      var browser = 'Safari';
+      var image = 'baz.png';
+
+      var browserPath = path.join(storage._shasPath, sha, browser);
+      var imagePath = path.join(browserPath, image);
+
+      return fs.ensureDirAsync(browserPath)
+      .then(function() {
+        return imageData.writeImageAsync(imagePath);
+      })
+      .then(function() {
+        return storage.getImage({
+          sha: sha,
+          browser: browser,
+          image: image
+        });
+      })
+      .then(function(data) {
+        assert.deepEqual(data, {
+          width: imageData.getWidth(),
+          height: imageData.getHeight(),
+          data: imageData.getBlob()
+        });
+      });
+
+    });
+  });
 });

--- a/test/tarHelper-test.js
+++ b/test/tarHelper-test.js
@@ -6,7 +6,7 @@ var TarHelper = require('../server/utils/tarHelper');
 var PNGImage = Bluebird.promisifyAll(require('pngjs-image'));
 var path = require('path');
 
-describe('TarHelper', function() {
+describe('module/tarHelper', function() {
   describe('getFilesInTar', function() {
     it('should read files', function() {
       var fixturePath = path.join(__dirname, 'fixtures', 'simple.tar.gz');


### PR DESCRIPTION
Handling 'check builds on update' from #2 
- [x] calculateDiffs
  - [x] diffing across browsers with different shas, only diff the common browsers
  - [x] diffing two folders of browsers, only diff the common images
  - [x] create image diffs
    - [x] diff the images
    - [x] save the results to build storage
    - [x] return the file names of diffs
- [x] merge resulting file names
- [x] merge resulting browsers and file names
  - [x] if file names 
    - [x] set status to failed
    - [x] save resulting diff images
    - [x] save json to build info
