### PR TITLE
Implementing confirm.

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -130,7 +130,8 @@ module.exports = function(options) {
   /*
   Approve a build
   POST Params
-  - id
+  - project string
+  - build string
   Response:
   {
       status: "success"

--- a/server/utils/storage.js
+++ b/server/utils/storage.js
@@ -222,9 +222,9 @@ var Storage = {
     assert.isObject(options);
     assert.isString(options.project);
     assert.isString(options.build);
-    assert.include(['success', 'failed'], options.status);
+    assert.isString(options.status);
 
-    if (options.status === 'failed') {
+    if (options.diffs) {
       assert.isObject(options.diffs);
     }
 
@@ -241,12 +241,7 @@ var Storage = {
     })
     .then(function(data) {
       data.status = status;
-
-      if (status === 'success') {
-        delete data.diffs;
-      } else if (status === 'failed') {
-        data.diffs = diffs;
-      }
+      data.diffs = diffs;
 
       return fs.outputJSONAsync(buildFile, data);
     });


### PR DESCRIPTION
storage.updateBuildInfo now requires passing in both status and diffs
